### PR TITLE
Fix autopublish to not exit on publish failure

### DIFF
--- a/autopublish-js.sh
+++ b/autopublish-js.sh
@@ -10,7 +10,7 @@ else
   echo -e "\n⚠️  ${RED}Error:${NC} copy-service not found!\n"
   exit 1;
 fi
-npm run autopublish || exit 1
+npm run autopublish
 
 if cd evaluators/plain-text-evaluator;
 then
@@ -19,7 +19,7 @@ else
   echo -e "\n⚠️  ${RED}Error:${NC} evaluators/plain-text-evaluator not found!\n"
   exit 1;
 fi
-npm run autopublish || exit 1
+npm run autopublish
 
 if cd ../react-evaluator;
 then
@@ -28,4 +28,4 @@ else
   echo -e "\n⚠️  ${RED}Error:${NC} evaluators/react-evaluator not found!\n"
   exit 1;
 fi
-npm run autopublish || exit 1
+npm run autopublish


### PR DESCRIPTION
### Copy Service PR

**Language clients modified**
- [x] js
- [ ] ruby

**Packages modified (add appropriate labels)**
- [ ] copy-service
- [ ] plain-text-evaluator
- [ ] react-evaluator

**Version change (add appropriate label)**
- [ ] Major - Non-backwards compatible changes
- [ ] Minor - Backwards compatible changes
- [ ] Patch - Backwards-compatible bug fix
- [x] None - Internal changes

**Are all packages using the latest version of their copy service dependencies?**
- [x] Yes
- [ ] No (Add comment)

**Notes:**
If autopublish fails because the module version already exists, the script should be able to continue to attempt to publish the other modules.