### PR TITLE
Add RefSubstitute, allowing for evaluated copyKey substitutions [PLAT-18983]

### DIFF
--- a/js/copy-service/CopyService.js
+++ b/js/copy-service/CopyService.js
@@ -4,6 +4,7 @@ import Formatting from './Formatting/Formatting';
 import Functional from './Functional/Functional';
 import Newline from './Newline/Newline';
 import Reference from './Reference/Reference';
+import RefSubstitute from './RefSubstitute/RefSubstitute';
 import Substitute from './Substitute/Substitute';
 import Switch from './Switch/Switch';
 import Verbatim from './Verbatim/Verbatim';
@@ -12,7 +13,7 @@ import Parser from './Parser/Parser';
 
 /**
  * An AST class.
- * @typedef {Formatting|Functional|Newline|Reference|Substitute|Switch|Verbatim} AST
+ * @typedef {Formatting|Functional|Newline|Reference|RefSubstitute|Substitute|Switch|Verbatim} AST
  */
 
 /**
@@ -30,6 +31,7 @@ class CopyService {
       object instanceof Functional ||
       object instanceof Newline ||
       object instanceof Reference ||
+      object instanceof RefSubstitute ||
       object instanceof Substitute ||
       object instanceof Switch ||
       object instanceof Verbatim;

--- a/js/copy-service/Parser/Parser.js
+++ b/js/copy-service/Parser/Parser.js
@@ -4,6 +4,7 @@ import Formatting from '../Formatting/Formatting';
 import Functional from '../Functional/Functional';
 import Newline from '../Newline/Newline';
 import Reference from '../Reference/Reference';
+import RefSubstitute from '../RefSubstitute/RefSubstitute';
 import Substitute from '../Substitute/Substitute';
 import Switch from '../Switch/Switch';
 import Verbatim from '../Verbatim/Verbatim';
@@ -14,6 +15,7 @@ const TOKENS = {
   CLOSE: '}',
   REF_START: '${',
   SUB_START: '\#{', // eslint-disable-line no-useless-escape
+  REF_SUB_START: '%{',
   SWITCH_START: '*{',
   FUNC_START: '^{',
   HTML_TAG_START: '<',
@@ -396,6 +398,22 @@ class Parser {
 
       return {
         ast: new Reference({
+          key: textParsed.text,
+          sibling: parsed.ast
+        }),
+        tokens: parsed.tokens
+      };
+    }
+
+    else if (token.type === this.TOKENS.REF_SUB_START) {
+      const textParsed = this._getTextToken(tokensToParse);
+      const closeParsedTokens = this._processCloseToken(textParsed.tokens);
+      const parsed = isRestricted ?
+        this._parseTokens(closeParsedTokens, true, expectedEndingToken) :
+        this._parseTokens(closeParsedTokens);
+
+      return {
+        ast: new RefSubstitute({
           key: textParsed.text,
           sibling: parsed.ast
         }),

--- a/js/copy-service/Parser/Parser.test.js
+++ b/js/copy-service/Parser/Parser.test.js
@@ -6,6 +6,7 @@ import Formatting from '../Formatting/Formatting';
 import Functional from '../Functional/Functional';
 import Newline from '../Newline/Newline';
 import Reference from '../Reference/Reference';
+import RefSubstitute from '../RefSubstitute/RefSubstitute';
 import Substitute from '../Substitute/Substitute';
 import Switch from '../Switch/Switch';
 import Verbatim from '../Verbatim/Verbatim';
@@ -77,6 +78,22 @@ describe('Parser', () => {
               };
               const expectedTree = {
                 substitution: new Substitute({
+                  key: 'hello',
+                  sibling: null
+                })
+              };
+
+              expect(Parser.parseLeaves(initialTree)).toEqual(expectedTree);
+            });
+          });
+
+          describe('when the tree contains a reference substitution', () => {
+            test('completes a parse with an AST containing a RefSubstitute node', () => {
+              const initialTree = {
+                substitution: '%{hello}'
+              };
+              const expectedTree = {
+                substitution: new RefSubstitute({
                   key: 'hello',
                   sibling: null
                 })

--- a/js/copy-service/RefSubstitute/RefSubstitute.js
+++ b/js/copy-service/RefSubstitute/RefSubstitute.js
@@ -1,0 +1,22 @@
+/**
+ * Represents a substitution of a copy key reference in an AST.
+ */
+class RefSubstitute {
+  /**
+   * @param  {object} options
+   */
+  constructor(options) {
+    /**
+     * The copy key being referenced, with leading and trailing whitespace trimmed.
+     * @type {string}
+     */
+    this.key = options.key.trim();
+    /**
+     * The neighboring AST.
+     * @type {Formatting|Functional|Newline|Reference|Substitute|Switch|Verbatim}
+     */
+    this.sibling = options.sibling;
+  }
+}
+
+export default RefSubstitute;

--- a/js/copy-service/RefSubstitute/RefSubstitute.test.js
+++ b/js/copy-service/RefSubstitute/RefSubstitute.test.js
@@ -1,0 +1,32 @@
+import RefSubstitute from './RefSubstitute';
+
+describe('RefSubstitute', () => {
+  describe('constructor', () => {
+    test('sets valid options to the instance', () => {
+      const options = {
+        sibling: new RefSubstitute({ key: 'some key' }),
+        key: 'some key'
+      };
+
+      const reference = new RefSubstitute(options);
+      expect(reference).toEqual(expect.objectContaining(options));
+    });
+
+    test('does not set invalid options to the instance', () => {
+      const options = {
+        ast: 'some ast',
+        text: 'some text',
+        arg: 'some arg',
+        copy: 'some copy',
+
+        key: 'some key'
+      };
+
+      const reference = new RefSubstitute(options);
+      expect(reference.ast).toBeUndefined();
+      expect(reference.text).toBeUndefined();
+      expect(reference.arg).toBeUndefined();
+      expect(reference.copy).toBeUndefined();
+    });
+  });
+});

--- a/js/index.js
+++ b/js/index.js
@@ -2,6 +2,7 @@ import Formatting from './copy-service/Formatting/Formatting';
 import Functional from './copy-service/Functional/Functional';
 import Newline from './copy-service/Newline/Newline';
 import Reference from './copy-service/Reference/Reference';
+import RefSubstitute from './copy-service/RefSubstitute/RefSubstitute';
 import Substitute from './copy-service/Substitute/Substitute';
 import Switch from './copy-service/Switch/Switch';
 import Verbatim from './copy-service/Verbatim/Verbatim';
@@ -15,6 +16,7 @@ export {
   Functional,
   Newline,
   Reference,
+  RefSubstitute,
   Substitute,
   Switch,
   Verbatim,


### PR DESCRIPTION
### Copy Service PR

**Language clients modified**
- [x] js
- [ ] ruby

**Packages modified (add appropriate labels)**
- [x] copy-service
- [ ] plain-text-evaluator
- [ ] react-evaluator

**Version change (add appropriate label)**
- [ ] Major - Non-backwards compatible changes
- [x] Minor - Backwards compatible changes
- [ ] Patch - Backwards-compatible bug fix
- [ ] None - Internal changes

**Are all packages using the latest version of their copy service dependencies?**
- [ ] Yes
- [x] No (Add comment)

**Notes:**
