### PR TITLE
specify main branch correctly

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,8 @@
 name: 'Publish NPM'
 on:
   push:
-    branches: [ $default-branch ]
+    branches:
+      - main
 
 jobs:
   test:


### PR DESCRIPTION
💩 Evidently the `$default-branch` in the example I looked at meant: "replace me with your default branch".