### PR TITLE
Add shorthand for relative copy key references

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,14 @@ Valid HTML tags are  `<strong>`, `<u>`, `<sup>`, `<sub>`, `<s>`, `<em>`, `<p>`, 
     "save": "<strong>Save</strong>",
     "cancel": "<q>Cancel</q>",
     "rollover": "^{You may rollover}[rollover]",
-    "implement": "^{You are going to implement}[implement][true]"
+    "implement": "^{You are going to implement}[implement][true]",
+  },
+  "relativeKeyProof": {
+    "two": "in a ${.nested.three}",
+    "nested": {
+      "one": "You can reference keys ${..two}.",
+      "three": "relative way",
+    }
   }
 }
 ```
@@ -165,6 +172,7 @@ Valid HTML tags are  `<strong>`, `<u>`, `<sup>`, `<sub>`, `<s>`, `<em>`, `<p>`, 
 - `account.name` will resolve to `'Account'`.
 - `account.description` will resolve to `'Checking Account'`.
 - `account.recursiveProof` will resolve to `'Checking Account'`.
+- `relativeKeyProof.nested.one` will resolve to `'You can reference keys in a relative way.'`.
 - `account.value` with substitutions `{ accountValue: 100 }` will resolve to `'$100'`.
 - `account.subbedCharacter` with substitutions `{ character: 'account.characters.savings' }` will resolve to `'Savings Account'`.
 - `account.owner` with substitutions `{ isSpouse: true }` will resolve to `'Spouse'`.

--- a/integration-tests/copy.json
+++ b/integration-tests/copy.json
@@ -19,7 +19,21 @@
   "references": {
     "title": "${verbatim.balance} and ${verbatim.pluralTitle}",
     "owner": "${verbatim.owner}",
-    "symbol": "${substitutions.symbol}"
+    "symbol": "${substitutions.symbol}",
+    "relative": {
+      "primary": "${.first}; ${.second}?",
+      "first": "And it's me you need to show",
+      "second": "how deep ${.deeperStill.infinite}",
+      "causeWere": "Cause we're livin in a world of fools, ${..so.broken}, when they all should let us be...",
+      "lyric": "I really mean to learn. ${.causeWere}",
+      "deeperStill": {
+        "infinite": "is your love",
+        "further": "${..lyric}"
+      }
+    },
+    "so": {
+      "broken": "breaking us down"
+    }
   },
   "referenceSubstitutions": {
     "title": "%{substitution}"

--- a/integration-tests/tests/PlainTextEvaluatorIntegration.test.js
+++ b/integration-tests/tests/PlainTextEvaluatorIntegration.test.js
@@ -114,6 +114,15 @@ describe('CopyService - PlainTextEvaluator Integration Tests', () => {
           expectedCopy: 'Account Owner'
         });
       });
+
+      describe('when the reference is relative', () => {
+        describe('references.relative.primary', () => {
+          testCopy({
+            key: 'references.relative.primary',
+            expectedCopy: 'And it\'s me you need to show; how deep is your love?'
+          });
+        });
+      });
     });
 
     describe('copy with copy key substitutions', () => {
@@ -294,6 +303,16 @@ describe('CopyService - PlainTextEvaluator Integration Tests', () => {
             },
             expectedCopy: 'some sub'
           });
+        });
+      });
+    });
+
+    describe('copy with multi-level relative references', () => {
+      describe('references.relative.deeperStill.further', () => {
+        testCopy({
+          key: 'references.relative.deeperStill.further',
+          expectedCopy: 'I really mean to learn. Cause we\'re livin in a world of fools,' +
+          ' breaking us down, when they all should let us be...'
         });
       });
     });

--- a/js/copy-service/CopyService.js
+++ b/js/copy-service/CopyService.js
@@ -67,7 +67,7 @@ class CopyService {
     const subkeys = this.getSubkeys(key);
 
     return _.mapValues(subkeys, (obj, path) => {
-      const subPath = `${key}.${path}`;
+      const subPath = `${key}${Parser.KEY_DELIMITER}${path}`;
       if (_.isPlainObject(obj)) {
         return this.buildSubkeys(subPath);
       }
@@ -107,7 +107,7 @@ class CopyService {
 
     if (_.isString(result)) { // need to parse to an AST
       try {
-        const ast = Parser.parseSingle(result);
+        const ast = Parser.parseSingle(key, result);
         _.set(this._registeredCopy, key, ast);
         return ast;
       } catch (ex) {

--- a/js/copy-service/CopyService.test.js
+++ b/js/copy-service/CopyService.test.js
@@ -143,6 +143,8 @@ describe('CopyService', () => {
     });
 
     describe('when the copy at the key has not been parsed', () => {
+      const key = 'some.key';
+
       beforeEach(() => {
         copyService.registerCopy({
           some: {
@@ -156,19 +158,19 @@ describe('CopyService', () => {
         const parsed = new SyntaxNode();
 
         jest.spyOn(Parser, 'parseSingle').mockReturnValue(parsed);
-        expect(copyService.getAstForKey('some.key')).toBe(parsed);
+        expect(copyService.getAstForKey(key)).toBe(parsed);
         expect(copyService._registeredCopy.some.key).toBe(parsed);
-        expect(Parser.parseSingle).toBeCalledWith(rawCopy);
+        expect(Parser.parseSingle).toBeCalledWith(key, rawCopy);
       });
 
       describe('when the copy fails to parse', () => {
         test('logs a waring and returns nil', () => {
           jest.spyOn(Parser, 'parseSingle').mockImplementation(() => { throw new Error(); });
 
-          expect(copyService.getAstForKey('some.key')).toBeNull();
+          expect(copyService.getAstForKey(key)).toBeNull();
           expect(ErrorHandler.handleError).toBeCalledWith(
             'CopyService',
-            'Failed to parse copy key: some.key. Returning null...'
+            `Failed to parse copy key: ${key}. Returning null...`
           );
         });
       });
@@ -312,8 +314,10 @@ describe('CopyService', () => {
     });
 
     describe('when an AST', () => {
+      const key = 'some.key';
+
       beforeEach(() => {
-        _.set(copyService._registeredCopy, 'some.key', Parser.parseSingle('some #{key} yo!'));
+        _.set(copyService._registeredCopy, key, Parser.parseSingle(key, 'some #{key} yo!'));
       });
 
       test('returns the corresponding string', () => {

--- a/js/copy-service/Parser/Parser.test.js
+++ b/js/copy-service/Parser/Parser.test.js
@@ -575,6 +575,7 @@ describe('Parser', () => {
 
     describe('when the value is a string', () => {
       test('tokenizes and parses the string', () => {
+        const key = 'some key';
         const result = { some: 'ast' };
         jest.spyOn(Parser, '_parse').mockReturnValue(result);
 
@@ -582,10 +583,10 @@ describe('Parser', () => {
         jest.spyOn(Parser, '_tokenize').mockReturnValue(tokens);
 
         const copy = 'some copy';
-        expect(Parser.parseSingle(copy)).toBe(result);
+        expect(Parser.parseSingle(key, copy)).toBe(result);
 
         expect(Parser._tokenize).toBeCalledWith(copy);
-        expect(Parser._parse).toBeCalledWith(tokens, copy);
+        expect(Parser._parse).toBeCalledWith(tokens, key, copy);
       });
     });
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcapital/copy-service",
-  "version": "5.1.1",
+  "version": "5.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcapital/copy-service",
-  "version": "5.1.1",
+  "version": "5.2.0",
   "description": "A modern library for UI copy management.",
   "license": "Apache-2.0",
   "main": "js/index.js",


### PR DESCRIPTION
Allows copy keys to be referenced relative to the parent key by prefixing the reference with `.`.
E.g. from integration-tests/copy.json,
```
{
  "relative": {
    "primary": "${.first}, and ${.second}",
    "first": "some relative copy",
    "second": "some other relative copy"
  }
}
```
The key `relative.primary` looks-up and interpolates `relative.first` and `relative.second`, returning the string
`some relative copy, and some other relative copy`.


Signed-off-by: Jeff Gibson <gibsonj@nextcapital.com>

## Pull Request Checklist

<!--

🚨 THIS REPO IS PUBLIC! Be mindful of what you post here. 🚨

-->

#### Components modified

- [x] copy-service
- [ ] html-evaluator
- [ ] plain-text-evaluator
- [ ] react-evaluator

#### Version change

We use [Semantic Versioning 2.0](https://semver.org/)

- [ ] Major - Non-backwards compatible changes
- [x] Minor - Backwards compatible changes
- [ ] Patch - Backwards-compatible bug fix
- [ ] None - Internal changes

#### Procedural Steps

All commits have been signed-off for the Developer Certificate of Origin. See https://github.com/NextCapital/copy-service/blob/main/CONTRIBUTING.md#dco-sign-off-methods

#### **Notes:**

This changes the signature of `Parser.parseSingle`, which is a public method.
I don't think users will be implementing Evaluators that invoke `parseSingle` directly, so this should be backwards-compatible (minor version), right?
