### PR TITLE
Add wordbreak character support [RTL-8689]

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -13,6 +13,7 @@
     "UX",
     "UXF",
     "VDS",
+    "wbr",
 
     "argify",
     "camelize",

--- a/README.md
+++ b/README.md
@@ -176,7 +176,8 @@ Valid HTML tags are  `<strong>`, `<u>`, `<sup>`, `<sub>`, `<s>`, `<em>`, `<p>`, 
     "save": "<strong>Save</strong>",
     "cancel": "<q>Cancel</q>",
     "rollover": "^{You may rollover}[rollover]",
-    "implement": "^{You are going to implement}[implement][true]"
+    "implement": "^{You are going to implement}[implement][true]",
+    "wordbreak": "Step\b 3 of 10"
   },
   "relativeKeyProof": {
     "two": "in a ${.nested.three}",
@@ -211,6 +212,7 @@ Valid HTML tags are  `<strong>`, `<u>`, `<sup>`, `<sub>`, `<s>`, `<em>`, `<p>`, 
 - With the `PlainTextEvaluator`, `account.rollover` with substitutions `{ rollover: (copy) => copy + 'your external IRA' }` will resolve to `'You may rollover'` if `allowFormatting` is false, and `'You may rollover your external IRA'` if it is `true`.
 - With the `ReactEvaluator`, `account.rollover` will resolve to `You may rollover your external IRA`.
 - With the `HtmlEvaluator`, `account.implement` with substitutions `{ implement: (copy, addMore) => copy + 'your NextCapital managed account' }` will resolve to `'You are going to implement your NextCapital managed account'`.
+- With the `HtmlEvaluator` and `ReactEvaluator`, `account.wordbreak` will resolve to `Step<wbr/> 3 of 10`. Note: `\b` is custom language syntax to this project.
 - With the `ReactEvaluator`, `link.example` with substitutions `{ makeLink: (copy, url) => (<a href={ url }>{ copy }</a>) }` will resolve to `Visit our <a href="https://nextcapital.com">fancy website</a>!`.
 
 ## Internationalization (i18n)

--- a/js/copy-service/Parser/Parser.js
+++ b/js/copy-service/Parser/Parser.js
@@ -9,6 +9,7 @@ const RefSubstitute = require('../RefSubstitute/RefSubstitute');
 const Substitute = require('../Substitute/Substitute');
 const Switch = require('../Switch/Switch');
 const Verbatim = require('../Verbatim/Verbatim');
+const WordBreak = require('../WordBreak/WordBreak');
 
 const ErrorHandler = require('../ErrorHandler/ErrorHandler');
 
@@ -30,7 +31,8 @@ const TOKENS = {
   ARGS_START: '}[',
   ARGS_COMMA: ',',
   ARGS_END: ']',
-  NEWLINE: '\n'
+  NEWLINE: '\n',
+  WORD_BREAK: '\b'
 };
 
 /**
@@ -421,6 +423,16 @@ class Parser {
         this._parseTokens(tokensToParse, key);
       return {
         ast: new Newline({ sibling: parsed.ast }),
+        tokens: parsed.tokens
+      };
+    }
+
+    else if (token.type === this.TOKENS.WORD_BREAK) {
+      const parsed = isRestricted ?
+        this._parseTokens(tokensToParse, key, true, expectedEndingToken) :
+        this._parseTokens(tokensToParse, key);
+      return {
+        ast: new WordBreak({ sibling: parsed.ast }),
         tokens: parsed.tokens
       };
     }

--- a/js/copy-service/Parser/Parser.test.js
+++ b/js/copy-service/Parser/Parser.test.js
@@ -12,6 +12,7 @@ const Switch = require('../Switch/Switch');
 const Verbatim = require('../Verbatim/Verbatim');
 
 const Parser = require('./Parser');
+const WordBreak = require('../WordBreak/WordBreak');
 
 describe('Parser', () => {
   afterEach(() => {
@@ -110,6 +111,21 @@ describe('Parser', () => {
               };
               const expectedTree = {
                 newline: new Newline({
+                  sibling: null
+                })
+              };
+
+              expect(Parser.parseLeaves(initialTree)).toEqual(expectedTree);
+            });
+          });
+
+          describe('when the tree contains a wordbreak', () => {
+            test('completes a parse with an AST containing a WordBreak node', () => {
+              const initialTree = {
+                wordbreak: '\b'
+              };
+              const expectedTree = {
+                wordbreak: new WordBreak({
                   sibling: null
                 })
               };
@@ -283,7 +299,7 @@ describe('Parser', () => {
           describe('when a tree contains copy nested inside HTML tags', () => {
             test('parses the nested copy successfully', () => {
               const initialTree = {
-                tags: '<strong><em>${hello}\n#{sub}</em></strong>'
+                tags: '<strong><em>${hello}\n#{sub}\bgood bye</em></strong>'
               };
               const expectedTree = {
                 tags: new Formatting({
@@ -293,7 +309,12 @@ describe('Parser', () => {
                       sibling: new Newline({
                         sibling: new Substitute({
                           key: 'sub',
-                          sibling: null
+                          sibling: new WordBreak({
+                            sibling: new Verbatim({
+                              text: 'good bye',
+                              sibling: null
+                            })
+                          })
                         })
                       })
                     }),

--- a/js/copy-service/WordBreak/WordBreak.js
+++ b/js/copy-service/WordBreak/WordBreak.js
@@ -1,0 +1,41 @@
+const SyntaxNode = require('../SyntaxNode/SyntaxNode');
+
+/**
+ * Represents a word break in an AST.
+ */
+class WordBreak extends SyntaxNode {
+  /**
+   * @param  {object} options
+   */
+  constructor(options) {
+    super(options);
+
+    /**
+     * The neighboring AST.
+     * @type {SyntaxNode|null}
+     */
+    this.sibling = options.sibling || null;
+  }
+
+  /**
+   * @returns {boolean} true if this node can be cached after evaluation
+   */
+  isCacheable(copyService) {
+    if (this.sibling) {
+      return this.sibling.isCacheable(copyService);
+    }
+
+    return true;
+  }
+
+  /**
+   * Converts the AST node to the syntax that made it.
+   *
+   * @return {string}
+   */
+  toSyntax() {
+    return `\b${this.safeToSyntax(this.sibling)}`;
+  }
+}
+
+module.exports = WordBreak;

--- a/js/copy-service/WordBreak/WordBreak.test.js
+++ b/js/copy-service/WordBreak/WordBreak.test.js
@@ -1,0 +1,68 @@
+const Verbatim = require('../Verbatim/Verbatim');
+const WordBreak = require('./WordBreak');
+const CopyService = require('../CopyService');
+
+describe('WordBreak', () => {
+  describe('constructor', () => {
+    test('sets valid options to the instance', () => {
+      const options = { sibling: new WordBreak({}) };
+
+      const wordbreak = new WordBreak(options);
+      expect(wordbreak).toEqual(expect.objectContaining(options));
+    });
+
+    test('does not set invalid options to the instance', () => {
+      const options = {
+        ast: 'some ast',
+        text: 'some text',
+        arg: 'some arg',
+        key: 'some key',
+        copy: 'some copy'
+      };
+
+      const wordbreak = new WordBreak(options);
+      expect(wordbreak.ast).toBeUndefined();
+      expect(wordbreak.text).toBeUndefined();
+      expect(wordbreak.arg).toBeUndefined();
+      expect(wordbreak.key).toBeUndefined();
+      expect(wordbreak.copy).toBeUndefined();
+    });
+  });
+
+  describe('isCacheable', () => {
+    let copyService;
+
+    beforeEach(() => {
+      copyService = new CopyService();
+    });
+
+    describe('when there is a sibling', () => {
+      test('defers to the sibling', () => {
+        const options = { sibling: new WordBreak({}) };
+
+        const wordbreak = new WordBreak(options);
+
+        jest.spyOn(wordbreak.sibling, 'isCacheable').mockReturnValue(false);
+        expect(wordbreak.isCacheable(copyService)).toBe(false);
+        expect(wordbreak.sibling.isCacheable).toBeCalledWith(copyService);
+      });
+    });
+
+    describe('when there is no sibling', () => {
+      test('returns true', () => {
+        const options = { sibling: null };
+
+        const wordbreak = new WordBreak(options);
+
+        expect(wordbreak.isCacheable(copyService)).toBe(true);
+      });
+    });
+  });
+
+  describe('toSyntax', () => {
+    test('converts back to a copy string', () => {
+      const wordbreak = new WordBreak({ sibling: new Verbatim({ text: 'some text' }) });
+      expect(wordbreak.toSyntax()).toBe('\bsome text');
+    });
+  });
+});

--- a/js/html-evaluator/HtmlEvaluator.js
+++ b/js/html-evaluator/HtmlEvaluator.js
@@ -16,6 +16,15 @@ class HtmlEvaluator extends PlainTextEvaluator {
   }
 
   /**
+   * `HtmlEvaluator` treats `WordBreak` nodes as `<wbr/>` tags.
+   *
+   * @returns {string}
+   */
+  getWordBreak() {
+    return '<wbr/>';
+  }
+
+  /**
    * `HtmlEvaluator` allows `Formatting` AST nodes to include their tags.
    *
    * @returns {boolean}

--- a/js/html-evaluator/HtmlEvaluator.test.js
+++ b/js/html-evaluator/HtmlEvaluator.test.js
@@ -33,4 +33,10 @@ describe('HTMLEvaluator', () => {
       expect(evaluator.getNewline()).toBe('<br/>');
     });
   });
+
+  describe('getWordBreak', () => {
+    test('returns a wbr tag', () => {
+      expect(evaluator.getWordBreak()).toBe('<wbr/>');
+    });
+  });
 });

--- a/js/index.js
+++ b/js/index.js
@@ -6,6 +6,7 @@ const RefSubstitute = require('./copy-service/RefSubstitute/RefSubstitute');
 const Substitute = require('./copy-service/Substitute/Substitute');
 const Switch = require('./copy-service/Switch/Switch');
 const Verbatim = require('./copy-service/Verbatim/Verbatim');
+const WordBreak = require('./copy-service/WordBreak/WordBreak');
 
 const Evaluator = require('./copy-service/Evaluator/Evaluator');
 const Substitutions = require('./copy-service/Substitutions/Substitutions');
@@ -23,6 +24,7 @@ module.exports = {
   Substitute,
   Switch,
   Verbatim,
+  WordBreak,
 
   Evaluator,
   Substitutions,

--- a/js/plain-text-evaluator/PlainTextEvaluator.js
+++ b/js/plain-text-evaluator/PlainTextEvaluator.js
@@ -9,6 +9,7 @@ const {
   Substitute,
   Switch,
   Verbatim,
+  WordBreak,
 
   Evaluator
 } = require('../index.js');
@@ -44,6 +45,10 @@ class PlainTextEvaluator extends Evaluator {
     // Append a newline character.
     if (ast instanceof Newline) {
       copy = this.getNewline();
+    }
+    // Append a WordBreak character.
+    else if (ast instanceof WordBreak) {
+      copy = this.getWordBreak();
     }
     // Append the text of the Verbatim.
     else if (ast instanceof Verbatim) {
@@ -131,6 +136,14 @@ class PlainTextEvaluator extends Evaluator {
    */
   getNewline() {
     return '\n';
+  }
+
+  /**
+   * The output for the `WordBreak` AST node. Overridden by `HtmlEvaluator`.
+   * @returns {string}
+   */
+  getWordBreak() {
+    return '';
   }
 
   /**

--- a/js/plain-text-evaluator/PlainTextEvaluator.test.js
+++ b/js/plain-text-evaluator/PlainTextEvaluator.test.js
@@ -8,7 +8,8 @@ const {
   Switch,
   Verbatim,
   Substitutions,
-  CopyService
+  CopyService,
+  WordBreak
 } = require('../index.js');
 
 const PlainTextEvaluator = require('./PlainTextEvaluator');
@@ -81,6 +82,18 @@ describe('PlainTextEvaluator', () => {
 
             expect(evaluator.evalAST('', ast)).toBe(newlineResult);
             expect(evaluator.getNewline).toBeCalled();
+          });
+        });
+
+        describe('when the AST is a WordBreak', () => {
+          test('defers to getWordBreak', () => {
+            const ast = new WordBreak({});
+
+            const wordbreakResult = '';
+            jest.spyOn(evaluator, 'getWordBreak').mockReturnValue(wordbreakResult);
+
+            expect(evaluator.evalAST('', ast)).toBe(wordbreakResult);
+            expect(evaluator.getWordBreak).toBeCalled();
           });
         });
 
@@ -313,6 +326,12 @@ describe('PlainTextEvaluator', () => {
   describe('getNewline', () => {
     test('returns a newline character', () => {
       expect(evaluator.getNewline()).toBe('\n');
+    });
+  });
+
+  describe('getWordBreak', () => {
+    test('returns an empty string', () => {
+      expect(evaluator.getWordBreak()).toBe('');
     });
   });
 });

--- a/js/react-evaluator/ReactEvaluator.js
+++ b/js/react-evaluator/ReactEvaluator.js
@@ -10,6 +10,7 @@ const {
   Substitute,
   Switch,
   Verbatim,
+  WordBreak,
 
   Evaluator
 } = require('../index.js');
@@ -43,6 +44,8 @@ class ReactEvaluator extends Evaluator {
 
     if (ast instanceof Newline) {
       copy = React.createElement('br', null);
+    } else if (ast instanceof WordBreak) {
+      copy = React.createElement('wbr', null);
     } else if (ast instanceof Verbatim) {
       copy = ast.text;
     } else if (ast instanceof Reference) {

--- a/js/react-evaluator/ReactEvaluator.test.js
+++ b/js/react-evaluator/ReactEvaluator.test.js
@@ -11,7 +11,8 @@ const {
   Switch,
   Verbatim,
   Substitutions,
-  CopyService
+  CopyService,
+  WordBreak
 } = require('../index.js');
 
 const ReactEvaluator = require('./ReactEvaluator');
@@ -93,6 +94,14 @@ describe('ReactEvaluator', () => {
             const ast = new Newline({});
 
             expect(getStaticMarkup(null, ast)).toBe('<br/>');
+          });
+        });
+
+        describe('when the AST is a WordBreak', () => {
+          test('returns a span with a wbr element', () => {
+            const ast = new WordBreak({});
+
+            expect(getStaticMarkup(null, ast)).toBe('<wbr/>');
           });
         });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcapital/copy-service",
-  "version": "5.2.4",
+  "version": "5.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcapital/copy-service",
-      "version": "5.2.4",
+      "version": "5.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "lodash": "^4.17.21"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcapital/copy-service",
-  "version": "5.2.4",
+  "version": "5.3.0",
   "description": "A modern library for UI copy management.",
   "license": "Apache-2.0",
   "main": "js/index.js",


### PR DESCRIPTION
## Pull Request Checklist

<!--

🚨 THIS REPO IS PUBLIC! Be mindful of what you post here. 🚨

-->

#### Components modified

- [ ] copy-service
- [x] html-evaluator
- [x] plain-text-evaluator
- [x] react-evaluator

#### Version change

We use [Semantic Versioning 2.0](https://semver.org/)

- [ ] Major - Non-backwards compatible changes
- [x] Minor - Backwards compatible changes
- [ ] Patch - Backwards-compatible bug fix
- [ ] None - Internal changes

#### Procedural Steps

All commits have been signed-off for the Developer Certificate of Origin. See https://github.com/NextCapital/copy-service/blob/main/CONTRIBUTING.md#dco-sign-off-methods

#### **Notes:**

Add support for wordbreak characters to the copy service.
Note that `\b` in our syntax is used to represent a custom wordbreak character instead of the traditional regex match character.
