### PR TITLE
(COPILOT) Re-export CopyFile, CopySubkeys, RegisteredCopyNode, and AST types from barrel [ENG-16336]

### DIFF
--- a/js/index.ts
+++ b/js/index.ts
@@ -13,7 +13,14 @@ export { default as Substitutions } from './copy-service/Substitutions/Substitut
 
 export { default as ErrorHandler } from './copy-service/ErrorHandler/ErrorHandler.js';
 export { default as CopyService } from './copy-service/CopyService.js';
+export type {
+  AST,
+  CopyFile,
+  CopySubkeys,
+  RegisteredCopyNode
+} from './copy-service/CopyService.js';
 export { default as IntlCopyService } from './copy-service/IntlCopyService.js';
+export type { LanguageHierarchy } from './copy-service/IntlCopyService.js';
 
 export { default as PlainTextEvaluator } from './plain-text-evaluator/PlainTextEvaluator.js';
 export { default as HtmlEvaluator } from './html-evaluator/HtmlEvaluator.js';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcapital/copy-service",
-  "version": "7.1.0",
+  "version": "7.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcapital/copy-service",
-      "version": "7.1.0",
+      "version": "7.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "lodash": "^4.17.23"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcapital/copy-service",
-  "version": "7.1.0",
+  "version": "7.1.1",
   "description": "A modern library for UI copy management.",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Re-exports the `CopyFile`, `CopySubkeys`, `RegisteredCopyNode`, and `AST` types from the barrel `index.ts` so consumers using `moduleResolution: nodenext` can import them directly from `@nextcapital/copy-service`.

## Related/Required PRs


https://github.com/BLC/design-objects/pull/510