### PR TITLE
(COPILOT) Upgrade lodash to ^4.18.1 [ENG-17905]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcapital/copy-service",
-  "version": "7.2.0",
+  "version": "7.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcapital/copy-service",
-      "version": "7.2.0",
+      "version": "7.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "lodash": "^4.18.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "7.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "lodash": "^4.18.0"
+        "lodash": "^4.18.1"
       },
       "devDependencies": {
         "@babel/core": "^7.29.0",
@@ -7800,9 +7800,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.0.tgz",
-      "integrity": "sha512-l1mfj2atMqndAHI3ls7XqPxEjV2J9ZkcNyHpoZA3r2T1LLwDB69jgkMWh71YKwhBbK0G2f4WSn05ahmQXVxupA==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.memoize": {
@@ -16136,9 +16136,9 @@
       }
     },
     "lodash": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.0.tgz",
-      "integrity": "sha512-l1mfj2atMqndAHI3ls7XqPxEjV2J9ZkcNyHpoZA3r2T1LLwDB69jgkMWh71YKwhBbK0G2f4WSn05ahmQXVxupA=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
     },
     "lodash.memoize": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcapital/copy-service",
-  "version": "7.2.0",
+  "version": "7.2.1",
   "description": "A modern library for UI copy management.",
   "license": "Apache-2.0",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "homepage": "https://github.com/NextCapital/copy-service#readme",
   "dependencies": {
-    "lodash": "^4.18.0"
+    "lodash": "^4.18.1"
   },
   "devDependencies": {
     "@babel/core": "^7.29.0",


### PR DESCRIPTION
Upgrade lodash from `^4.18.0` to `^4.18.1` to keep dependencies up to date with the latest minor version.

## Pull Request Checklist

#### Components modified

- [x] copy-service
- [ ] html-evaluator
- [ ] plain-text-evaluator
- [ ] react-evaluator

#### Version change

We use [Semantic Versioning 2.0](https://semver.org/)

- [ ] Major - Non-backwards compatible changes
- [ ] Minor - Backwards compatible changes
- [x] Patch - Backwards-compatible bug fix
- [ ] None - Internal changes

#### Procedural Steps

All commits have been signed-off for the Developer Certificate of Origin. See https://github.com/NextCapital/copy-service/blob/main/CONTRIBUTING.md#dco-sign-off-methods

#### **Notes:**

Upgrade lodash from `^4.18.0` to `^4.18.1`.

- Ran `npm install` to update the lockfile
- Verified: lint (clean), tests (377/377 passed), tsc (clean), tsc:test (clean)


## Related/Required PRs


https://github.com/BLC/design-objects/pull/523